### PR TITLE
Bumping Franz to 5.7.0 and platform to 21.08. 

### DIFF
--- a/com.meetfranz.Franz.appdata.xml
+++ b/com.meetfranz.Franz.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <id>com.meetfranz.Franz</id>
-  <launchable>com.meetfranz.Franz.desktop</launchable>>
+  <launchable type="desktop-id">com.meetfranz.Franz.desktop</launchable>
   <name>Franz</name>
   <project_license>Apache-2.0</project_license>
   <developer_name>Stefan Maizner</developer_name>
@@ -21,7 +21,25 @@
     </screenshot>
   </screenshots>
   <releases>
-        <release version="5.5.0" date="2020-04-30">
+    <release version="5.7.0" date="2021-06-14">
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>App: Add support for screen sharing during video calls</li>
+        </ul>
+        <p>Bug Fixes:</p>
+        <ul>
+          <li>App: Fix app focus detection</li>
+	  <li>App: Various bugfixes and improvements</li>
+        </ul>
+        <p>General:</p>
+        <ul>
+          <li>App: Update electron to 12.0.6</li>
+          <li>Translations: Improved translations. A million thanks to the amazing community.</li>
+        </ul>
+      </description>
+    </release>
+    <release version="5.5.0" date="2020-04-30">
       <description>
         <p>Features:</p>
         <ul>

--- a/com.meetfranz.Franz.yaml
+++ b/com.meetfranz.Franz.yaml
@@ -1,8 +1,8 @@
 app-id: com.meetfranz.Franz
 base: org.electronjs.Electron2.BaseApp
-base-version: '20.08'
+base-version: '21.08'
 runtime: org.freedesktop.Platform
-runtime-version: '20.08'
+runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
 command: franz
 separate-locales: false
@@ -38,8 +38,8 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/meetfranz/franz/releases/download/v5.5.0/franz_5.5.0_amd64.deb
-        sha256: 9583941485ef4fe2357b7ec8a0415753e47f145c70d8aafbba0ffc0ba292ee4d
+        url: https://github.com/meetfranz/franz/releases/download/v5.7.0/franz_5.7.0_amd64.deb
+        sha256: 862b7e8f5ec5c9237008fb59e38ab2eb6ea5dc18363525a8f246338137ac10bf
       - type: script
         dest-filename: franz.sh
         commands:


### PR DESCRIPTION
Hi, I'm proposing this pull request to bump Franz version and dependencies. I've validated this flatpak against 21.08 platform version (including Electron).

The Electron/platform version bump is necessary to enable Slack support again.

Also updating .appdata.xml to reflect launchable type as required by freedesktop spec. Otherwise it doesn't run with newer flatpak-builder version.