### PR TITLE
Updating Franz to 5.8.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
+build-dir
 .flatpak-builder

--- a/com.meetfranz.Franz.appdata.xml
+++ b/com.meetfranz.Franz.appdata.xml
@@ -21,6 +21,31 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="5.8.0" date="2022-02-17">
+      <description>
+        <p>Bug Fixes:</p>
+        <ul>
+          <li>App: Fix potential memory leak with full screen event listeners</li>
+	        <li>macOS: Make tray icon color dynamic</li>
+          <li>macOS: Fix Do Not Disturb System check for macOS Monterey</li>
+          <li>Windows: Fix menu bar styling</li>
+          <li>Gmail: Fix auto suggest, calendar invites and other Google service integrations</li>
+          <li>Microsoft Teams: Fix issue that prevents loading chats</li>
+        </ul>
+        <p>Features:</p>
+        <ul>
+          <li>Service: Add modifyRequestHeaders for service recipes</li>
+          <li>App: Remove Google Analytics</li>
+          <li>Service Recipes: Add Franz.clearCache() method to clear service cache</li>
+        </ul>
+        <p>General:</p>
+        <ul>
+          <li>App: Update electron to 14.2.2</li>
+          <li>App: Various improvements all over the app</li>
+          <li>Translations: Improved translations. A million thanks to the amazing community.</li>
+        </ul>
+      </description>
+    </release>
     <release version="5.7.0" date="2021-06-14">
       <description>
         <p>Features:</p>
@@ -30,7 +55,7 @@
         <p>Bug Fixes:</p>
         <ul>
           <li>App: Fix app focus detection</li>
-	  <li>App: Various bugfixes and improvements</li>
+	        <li>App: Various bugfixes and improvements</li>
         </ul>
         <p>General:</p>
         <ul>

--- a/com.meetfranz.Franz.appdata.xml
+++ b/com.meetfranz.Franz.appdata.xml
@@ -21,6 +21,14 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="5.9.1" date="2022-04-04">
+      <description>
+        <p>Bug Fixes:</p>
+        <ul>
+          <li>macOS: Fix auto updater on macOS</li>
+        </ul>
+      </description>
+    </release>
     <release version="5.8.0" date="2022-02-17">
       <description>
         <p>Bug Fixes:</p>

--- a/com.meetfranz.Franz.yaml
+++ b/com.meetfranz.Franz.yaml
@@ -38,8 +38,8 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/meetfranz/franz/releases/download/v5.8.0/franz_5.8.0_amd64.deb
-        sha256: 2aabe8f02105e53b6611aad85a079a3f3074febe9bb180068e3f46681986d3d0
+        url: https://github.com/meetfranz/franz/releases/download/v5.9.1/franz_5.9.1_amd64.deb
+        sha256: 346b9ab9a61cbdd6ffccccd69fbea303d404cfd5fd89fcc943bf9f1d5b53f1ad
       - type: script
         dest-filename: franz.sh
         commands:

--- a/com.meetfranz.Franz.yaml
+++ b/com.meetfranz.Franz.yaml
@@ -38,8 +38,8 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/meetfranz/franz/releases/download/v5.7.0/franz_5.7.0_amd64.deb
-        sha256: 862b7e8f5ec5c9237008fb59e38ab2eb6ea5dc18363525a8f246338137ac10bf
+        url: https://github.com/meetfranz/franz/releases/download/v5.8.0/franz_5.8.0_amd64.deb
+        sha256: 2aabe8f02105e53b6611aad85a079a3f3074febe9bb180068e3f46681986d3d0
       - type: script
         dest-filename: franz.sh
         commands:


### PR DESCRIPTION
Hi I'm proposing this pull request to update Franz to latest release, this is specially important since (and according to changelog) fixes some issues with MS Teams chats.

https://meetfranz.com/changelog

I'm also adding build-dir to .gitignore since updates on Flatpak's official guide now propose a build-dir directory instead of build

https://docs.flatpak.org/en/latest/first-build.html