### PR TITLE
Bumping Franz to 5.9.2

### DIFF
--- a/com.meetfranz.Franz.appdata.xml
+++ b/com.meetfranz.Franz.appdata.xml
@@ -21,6 +21,25 @@
     </screenshot>
   </screenshots>
   <releases>
+  <release version="5.9.2" date="2022-04-19">
+      <description>
+        <p>Bug Fixes:</p>
+        <ul>
+          <li>Service: Apply Google login fix for all services</li>
+          <li>App: Don't reload app when coming back from system sleep</li>
+          <li>Windows + Linux: Introduce new Franz Menu</li>
+          <li>App: Improve layout rendering of services</li>
+          <li>Todos: Fix Todos to be resizable again</li>
+          <li>Todos: Fix Todos layout issues when Todos should be hidden</li>
+          <li>App: Don't let the app get confused by unknown routes</li>
+        </ul>
+        <p>Features:</p>
+        <ul>
+          <li>App: Lock user agents to Windows 10 and macOS 10.15.17 to avoid fingerprinting identification</li>
+          <li>App: Update to electron 18</li>
+        </ul>
+      </description>
+    </release>
     <release version="5.9.1" date="2022-04-04">
       <description>
         <p>Bug Fixes:</p>

--- a/com.meetfranz.Franz.yaml
+++ b/com.meetfranz.Franz.yaml
@@ -1,8 +1,8 @@
 app-id: com.meetfranz.Franz
 base: org.electronjs.Electron2.BaseApp
-base-version: '21.08'
+base-version: '22.08'
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: franz
 separate-locales: false
@@ -38,8 +38,8 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/meetfranz/franz/releases/download/v5.9.1/franz_5.9.1_amd64.deb
-        sha256: 346b9ab9a61cbdd6ffccccd69fbea303d404cfd5fd89fcc943bf9f1d5b53f1ad
+        url: https://github.com/meetfranz/franz/releases/download/v5.9.2/franz_5.9.2_amd64.deb
+        sha256: 5bfeb483909b49465c3404a375b892ec336ff77ef91a27ac106eb440b2c08758
       - type: script
         dest-filename: franz.sh
         commands:


### PR DESCRIPTION
Hi I'm proposing this pull request to update Franz to latest release (5.9.2).

I've been using this release as daily driver for a week and seems to be working, hence I propose this for the wider community at FlatHub, it also includes version bump for Freedesktop and Electron platforms.
