### PR TITLE
Bumping Franz to 5.10.0

### DIFF
--- a/com.meetfranz.Franz.appdata.xml
+++ b/com.meetfranz.Franz.appdata.xml
@@ -21,7 +21,22 @@
     </screenshot>
   </screenshots>
   <releases>
-  <release version="5.9.2" date="2022-04-19">
+    <release version="5.10.0" date="2023-09-01">
+      <description>
+        <p>Bug Fixes:</p>
+        <ul>
+          <li>fix automatic spellcheck language detection</li>
+          <li>Fix crash when Todos view is not initialized</li>
+          <li>Fix issue where service can't be initialized when spellchecking language is not set</li>
+          <li>Remove screen id from share screen dialogue</li>
+        </ul>
+        <p>Features:</p>
+        <ul>
+          <li>Update electron to 22.3.18</li>
+        </ul>
+      </description>
+    </release>
+    <release version="5.9.2" date="2022-04-19">
       <description>
         <p>Bug Fixes:</p>
         <ul>

--- a/com.meetfranz.Franz.appdata.xml
+++ b/com.meetfranz.Franz.appdata.xml
@@ -25,7 +25,7 @@
       <description>
         <p>Bug Fixes:</p>
         <ul>
-          <li>fix automatic spellcheck language detection</li>
+          <li>Fix automatic spellcheck language detection</li>
           <li>Fix crash when Todos view is not initialized</li>
           <li>Fix issue where service can't be initialized when spellchecking language is not set</li>
           <li>Remove screen id from share screen dialogue</li>

--- a/com.meetfranz.Franz.yaml
+++ b/com.meetfranz.Franz.yaml
@@ -38,8 +38,8 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/meetfranz/franz/releases/download/v5.9.2/franz_5.9.2_amd64.deb
-        sha256: 5bfeb483909b49465c3404a375b892ec336ff77ef91a27ac106eb440b2c08758
+        url: https://github.com/meetfranz/franz/releases/download/v5.10.0/franz_5.10.0_amd64.deb
+        sha256: cd0859971afb932316c7ab710e757e102053cd51309d4681b0b58a272dd76058
       - type: script
         dest-filename: franz.sh
         commands:


### PR DESCRIPTION
Hi I'm proposing this pull request to update Franz to latest release (5.10.0).

This is a minor bump that I've tested for 1 week.